### PR TITLE
bump up python version for lambda runtime to 3.9

### DIFF
--- a/modules/cloudwatch-alarm-actions/modules/lambda-subscription/main.tf
+++ b/modules/cloudwatch-alarm-actions/modules/lambda-subscription/main.tf
@@ -22,7 +22,7 @@ module "lambda" {
   create        = true
   function_name = local.lambda_name
   handler       = "lambda.handler"
-  runtime       = "python3.7"
+  runtime       = "python3.9"
   memory_size   = var.memory_size
   timeout       = var.timeout
 


### PR DESCRIPTION
Runtime python3.7 is not supported anymore. Bumped up the runtime to version 3.9